### PR TITLE
Pin Python 3.12 and Node

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+python = "3.12.10"
+node   = "22"

--- a/PromptConsole_TechSpec.md
+++ b/PromptConsole_TechSpec.md
@@ -49,7 +49,7 @@ Frontend (React + Vite + Tailwind)
   ├─ History Panel (filters/search)
   └─ Settings (recipes viewer/hot-reload)
 
-Backend (FastAPI, Python 3.11)
+Backend (FastAPI, Python 3.12)
   ├─ /choose      -> select recipe, (optional) enhance input, build engineered prompt
   ├─ /feedback    -> record reward components + aggregate reward
   ├─ /history     -> list recent decisions (with/without text)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Frontend (React + Vite + Tailwind)
   ├─ History Panel (filters/search)
   └─ Settings (recipes viewer/hot-reload)
 
-Backend (FastAPI, Python 3.11)
+Backend (FastAPI, Python 3.12)
   ├─ /choose      -> select recipe, (optional) enhance input, build engineered prompt
   ├─ /feedback    -> record reward components + aggregate reward
   ├─ /history     -> list recent decisions (with/without text)
@@ -37,6 +37,14 @@ Storage (SQLite via SQLAlchemy)
 ```
 
 ## Development Setup
+
+Run the following once to install the pinned Python (3.12.10) and Node (22) versions:
+
+```bash
+mise install
+# if you see an "untrusted" warning, run:
+mise trust .mise.toml
+```
 
 ### Backend
 ```bash


### PR DESCRIPTION
## Summary
- pin Python 3.12.10 and Node 22 in mise configuration for reproducible runtimes
- document pinned runtimes and upgrade docs to Python 3.12

## Testing
- `python -m pytest`
- `npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_b_68c5d366b288832e9421f292a495a4db