### PR TITLE
chore(Phase C): UI labels and docs wording to 'Prompt Templates' (no API changes)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@
 LOG_LEVEL=INFO
 DATABASE_URL=sqlite:///./console.sqlite
 RECIPES_DIR=./prompt-templates
+# Optional alias (takes precedence if set):
+# PROMPT_TEMPLATES_DIR=./prompt-templates
 STORE_TEXT=0
 EPSILON=0.10
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Frontend (React + Vite + Tailwind)
   ├─ Toolbar (Assistant, Category, Enhance toggle)
   ├─ Output Panel (Engineered Prompt + Copy, feedback buttons)
   ├─ History Panel (filters/search)
-  └─ Settings (recipes viewer/hot-reload)
+  └─ Settings (prompt templates viewer/hot-reload)
 
 Backend (FastAPI, Python 3.12)
   ├─ /choose      -> select recipe, (optional) enhance input, build engineered prompt
@@ -61,7 +61,7 @@ uvicorn app.main:app --reload --port 7070
 Logging
 - Set LOG_LEVEL=DEBUG to increase verbosity.
 
-Recipes cache
+Prompt templates cache (a.k.a. recipes)
 - Cached in-memory; GET /recipes?reload=true forces a refresh.
 
 Testing
@@ -71,7 +71,7 @@ pytest -q || python -m pytest -q
 ```
 
 Scripts
-- scripts/curl-examples.sh contains example curl commands for local verification.
+- scripts/curl-examples.sh contains example curl commands for local verification of /recipes (alias: /prompt-templates).
 
 ### Frontend
 ```bash

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Backend (FastAPI, Python 3.12)
   ├─ /feedback    -> record reward components + aggregate reward
   ├─ /history     -> list recent decisions (with/without text)
   ├─ /recipes     -> list recipes and validation errors
+  ├─ /prompt-templates -> alias of /recipes (Phase B, read-only)
   ├─ engine.py    -> deterministic operators
   ├─ optimizer.py -> ε-greedy scorer per assistant×category
   ├─ enhancer.py  -> optional local/hosted LLM rewriter
@@ -85,7 +86,8 @@ npm run dev
 Environment variables and defaults
 
 - Core
-  - RECIPES_DIR: Path to recipes directory (default backend/app/../../recipes)
+  - RECIPES_DIR: Path to prompt templates directory (default backend/app/../../prompt-templates)
+  - PROMPT_TEMPLATES_DIR: Optional alias for RECIPES_DIR; if set, it takes precedence (preferred going forward)
   - LOG_LEVEL: Logging level (default INFO)
   - DATABASE_URL: SQLAlchemy database URL (default sqlite:///./console.sqlite)
   - STORE_TEXT: 1 to store raw/engineered text with decisions; 0 to disable (default 0)
@@ -124,7 +126,7 @@ Hot-reload modes and env vars
 - RECIPES_RELOAD_INTERVAL_SECONDS: polling interval in seconds (default: 5)
 - RECIPES_DEBOUNCE_MS: debounce window for filesystem events in ms (default: 300)
 - RECIPES_RECURSIVE: watch `recipes/**/*.yaml` recursively when set to 1 (default: 0)
-- RECIPES_DIR: override recipes directory (default: repo recipes/)
+- RECIPES_DIR: override prompt templates directory (default: repo prompt-templates/)
 
 Force reload
 ```bash

--- a/docs/recipes_authoring.md
+++ b/docs/recipes_authoring.md
@@ -1,10 +1,10 @@
-# Authoring NeoPrompt Recipes
+# Authoring Prompt Templates (Recipes)
 
-This guide shows how to create and maintain recipes.
+This guide shows how to create and maintain prompt templates (formerly called "recipes").
 
 ## File layout
-- Main recipes live under `recipes/`.
-- Reusable fragments live under `recipes/_fragments/`.
+- Main prompt templates live under `prompt-templates/`.
+- Reusable fragments live under `prompt-templates/_fragments/`.
 
 ## Minimal recipe
 ```yaml

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -78,16 +78,16 @@ export default function SettingsModal({ open, onClose, storeText, onToggleStoreT
 
           <div className="flex items-center gap-2">
             <button onClick={refresh} className="bg-green-700 hover:bg-green-600 px-3 py-1 rounded disabled:opacity-50" disabled={loading}>
-              {loading ? 'Reloading…' : 'Reload Recipes'}
+              {loading ? 'Reloading…' : 'Reload Prompt Templates'}
             </button>
             {error && <span className="text-red-400 text-sm">{error}</span>}
           </div>
 
-          <div className="text-green-400">Loaded Recipes & Validation</div>
+          <div className="text-green-400">Loaded Prompt Templates & Validation</div>
 
           {recipes && (
             <div className="text-sm text-neutral-300 flex items-center gap-3">
-              <span>Recipes: <span className="text-green-400">{recipes.recipes?.length ?? 0}</span></span>
+              <span>Prompt Templates: <span className="text-green-400">{recipes.recipes?.length ?? 0}</span></span>
               <span>Diagnostics: <span className="text-green-400">{recipes.errors?.length ?? 0}</span></span>
             </div>
           )}


### PR DESCRIPTION
Phase C: user-facing wording updates only.

- Frontend Settings modal: 'Reload Prompt Templates'; 'Loaded Prompt Templates & Validation'; 'Prompt Templates: <count>'
- README: clarify settings section and cache naming, mention /prompt-templates alias in scripts line
- Docs: recipes_authoring.md retitled to 'Authoring Prompt Templates (Recipes)' and updated file layout to prompt-templates/

No API changes. All tests pass locally (34 passed, warnings only).