### PR TITLE
Fix backend DB initialization and Alembic typing

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
+
 import os
 from logging.config import fileConfig
-from sqlalchemy import engine_from_config, pool
+from typing import Any, cast
+
 from alembic import context
-from app.db import Base  # type: ignore
+from sqlalchemy import engine_from_config, pool
+
+from app.db import Base
 
 # Interpret the config file for Python logging.
 config = context.config
@@ -29,8 +33,17 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
+    config_section = config.config_ini_section
+    if config_section is None:
+        raise RuntimeError("Missing config_ini_section in Alembic configuration")
+
+    section = config.get_section(config_section)
+    if section is None:
+        raise RuntimeError(f"Missing config section: {config_section}")
+
+    options = dict(section)
     connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
+        cast(dict[str, Any], options),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -13,6 +13,8 @@ engine = create_engine(DATABASE_URL, echo=False)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
+_DB_INITIALIZED = False
+
 
 class Decision(Base):
     """Stores prompt engineering decisions."""
@@ -118,6 +120,7 @@ class BanditStats(Base):
 
 def get_db() -> Session:
     """Get database session."""
+    init_db()
     db = SessionLocal()
     try:
         yield db
@@ -125,11 +128,15 @@ def get_db() -> Session:
         db.close()
 
 
-def init_db():
+def init_db() -> None:
     """Initialize database tables."""
+    global _DB_INITIALIZED
+    if _DB_INITIALIZED:
+        return
     Base.metadata.create_all(bind=engine)
-    print("Database initialized successfully")
+    _DB_INITIALIZED = True
 
 
 if __name__ == "__main__":
     init_db()
+    print("Database initialized successfully")


### PR DESCRIPTION
## Summary
- add validation and stricter typing to the Alembic environment configuration loader
- lazily initialize the SQLite schema before handing out database sessions to avoid missing-table errors during tests

## Testing
- ruff check backend
- mypy -p backend
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68cc14bd7804832ea406bc79ec189777