### PR TITLE
Fix backend DB initialization and Alembic typing

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
+
 import os
 from logging.config import fileConfig
-from sqlalchemy import engine_from_config, pool
+from typing import Any, cast
+
 from alembic import context
-from app.db import Base  # type: ignore
+from sqlalchemy import engine_from_config, pool
+
+from app.db import Base
 
 # Interpret the config file for Python logging.
 config = context.config
@@ -29,8 +33,17 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
+    config_section = config.config_ini_section
+    if config_section is None:
+        raise RuntimeError("Missing config_ini_section in Alembic configuration")
+
+    section = config.get_section(config_section)
+    if section is None:
+        raise RuntimeError(f"Missing config section: {config_section}")
+
+    options = dict(section)
     connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
+        cast(dict[str, Any], options),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -13,6 +13,8 @@ engine = create_engine(DATABASE_URL, echo=False)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
+_DB_INITIALIZED = False
+
 
 class Decision(Base):
     """Stores prompt engineering decisions."""
@@ -118,6 +120,7 @@ class BanditStats(Base):
 
 def get_db() -> Session:
     """Get database session."""
+    init_db()
     db = SessionLocal()
     try:
         yield db
@@ -125,11 +128,15 @@ def get_db() -> Session:
         db.close()
 
 
-def init_db():
+def init_db() -> None:
     """Initialize database tables."""
+    global _DB_INITIALIZED
+    if _DB_INITIALIZED:
+        return
     Base.metadata.create_all(bind=engine)
-    print("Database initialized successfully")
+    _DB_INITIALIZED = True
 
 
 if __name__ == "__main__":
     init_db()
+    print("Database initialized successfully")

--- a/backend/app/engine.py
+++ b/backend/app/engine.py
@@ -1,6 +1,32 @@
 """Deterministic prompt engineering operators and prompt builder."""
 from __future__ import annotations
-from typing import List, Tuple
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple
+
+__all__ = [
+    "OperatorContext",
+    "OperatorBuilder",
+    "register_operator",
+    "build_prompt",
+    "op_role_hdr",
+    "op_constraints",
+    "op_io_format",
+    "op_examples",
+    "op_quality_bar",
+]
+
+
+@dataclass(frozen=True)
+class OperatorContext:
+    """Inputs shared by all operator builders."""
+
+    category: str
+    force_json: bool
+    examples: Sequence[str]
+
+
+OperatorBuilder = Callable[[OperatorContext], str | None]
 
 
 def op_role_hdr(category: str) -> str:
@@ -30,7 +56,7 @@ def op_io_format(force_json: bool) -> str:
     )
 
 
-def op_examples(examples: List[str]) -> str:
+def op_examples(examples: Sequence[str]) -> str:
     if not examples:
         return ""
     header = "Examples:"
@@ -43,42 +69,84 @@ def op_quality_bar() -> str:
     )
 
 
+def _build_role_hdr(ctx: OperatorContext) -> str:
+    return op_role_hdr(ctx.category)
+
+
+def _build_constraints(ctx: OperatorContext) -> str:
+    return op_constraints(ctx.category)
+
+
+def _build_io_format(ctx: OperatorContext) -> str:
+    return op_io_format(ctx.force_json)
+
+
+def _build_examples(ctx: OperatorContext) -> str | None:
+    return op_examples(ctx.examples)
+
+
+def _build_quality_bar(ctx: OperatorContext) -> str:
+    return op_quality_bar()
+
+
+_DEFAULT_OPERATORS: Dict[str, OperatorBuilder] = {
+    "role_hdr": _build_role_hdr,
+    "constraints": _build_constraints,
+    "io_format": _build_io_format,
+    "examples": _build_examples,
+    "quality_bar": _build_quality_bar,
+}
+
+
+def register_operator(
+    name: str,
+    builder: OperatorBuilder,
+    *,
+    registry: MutableMapping[str, OperatorBuilder] | None = None,
+    overwrite: bool = False,
+) -> None:
+    """Register or override a prompt operator builder."""
+
+    registry = _DEFAULT_OPERATORS if registry is None else registry
+    if not name:
+        raise ValueError("Operator name must be a non-empty string")
+    if not overwrite and name in registry:
+        raise ValueError(f"Operator '{name}' is already registered")
+    registry[name] = builder
+
+
 def build_prompt(
     raw_input: str,
     category: str,
-    operators: List[str],
+    operators: Iterable[str],
     *,
     force_json: bool = False,
-    examples: List[str] | None = None,
+    examples: Sequence[str] | None = None,
+    registry: Mapping[str, OperatorBuilder] | None = None,
 ) -> Tuple[str, List[str]]:
     """Assemble the engineered prompt using the specified operators in order.
     Returns: (prompt_text, applied_ops)
     """
+
     applied: List[str] = []
     blocks: List[str] = []
-    examples = examples or []
+    registry = registry or _DEFAULT_OPERATORS
+    context = OperatorContext(
+        category=category,
+        force_json=force_json,
+        examples=tuple(examples or ()),
+    )
 
     for op in operators:
-        if op == "role_hdr":
-            blocks.append(op_role_hdr(category))
-            applied.append(op)
-        elif op == "constraints":
-            blocks.append(op_constraints(category))
-            applied.append(op)
-        elif op == "io_format":
-            blocks.append(op_io_format(force_json))
-            applied.append(op)
-        elif op == "examples":
-            ex = op_examples(examples)
-            if ex:
-                blocks.append(ex)
-                applied.append(op)
-        elif op == "quality_bar":
-            blocks.append(op_quality_bar())
-            applied.append(op)
-        else:
+        builder = registry.get(op)
+        if builder is None:
             # Unknown operator: skip silently for robustness
             continue
+        block = builder(context)
+        if not block:
+            continue
+        blocks.append(block)
+        applied.append(op)
 
     # Raw task at the end
     blocks.append("TASK:\n" + raw_input.strip())

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,5 +1,4 @@
-import re
-from backend.app.engine import build_prompt
+from backend.app.engine import build_prompt, register_operator
 
 def test_build_prompt_force_json_instructions():
     prompt, applied = build_prompt(
@@ -26,3 +25,14 @@ def test_build_prompt_operator_order_deterministic():
     assert applied == ops
     # Ensure raw task appended at end
     assert prompt.strip().endswith("TASK:\nDo X")
+
+
+def test_build_prompt_custom_operator_registry():
+    register_operator("custom_block", lambda ctx: "Custom block", overwrite=True)
+    prompt, applied = build_prompt(
+        raw_input="Investigate",
+        category="science",
+        operators=["custom_block", "role_hdr"],
+    )
+    assert prompt.startswith("Custom block")
+    assert applied == ["custom_block", "role_hdr"]


### PR DESCRIPTION
## Summary
- add validation and stricter typing to the Alembic environment configuration loader
- lazily initialize the SQLite schema before handing out database sessions to avoid missing-table errors during tests
- refactor the prompt builder to use a registry-based operator system and cover custom operators in tests to resolve merge conflicts

## Testing
- ruff check backend tests/test_engine.py
- mypy -p backend
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68cc14bd7804832ea406bc79ec189777