### PR TITLE
chore/m0 tidyups

### DIFF
--- a/backend/cli/neoprompt.py
+++ b/backend/cli/neoprompt.py
@@ -96,6 +96,7 @@ def cmd_feedback(args: argparse.Namespace) -> None:
     payload: Dict[str, Any] = {
         "decision_id": args.decision_id,
         "reward": float(args.reward),
+        "reward_components": {},
     }
     if args.reward_components:
         try:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ prometheus-client==0.20.0
 watchfiles==0.21.0
 python-json-logger==2.0.7
 alembic==1.13.2
+jsonschema==4.23.0

--- a/conftest.py
+++ b/conftest.py
@@ -4,3 +4,8 @@ import sys
 ROOT = os.path.abspath(os.path.dirname(__file__))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
+
+# Ensure the Python SDK source is importable in tests without installation
+SDK_SRC = os.path.join(ROOT, "sdk", "python", "neoprompt", "src")
+if os.path.isdir(SDK_SRC) and SDK_SRC not in sys.path:
+    sys.path.insert(0, SDK_SRC)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -45,11 +45,21 @@ export async function apiHistory(params: { limit?: number; assistant?: string; c
 }
 
 export async function apiRecipes(reload?: boolean) {
-  const url = new URL(`${API_BASE}/recipes`);
-  if (reload) url.searchParams.set('reload', '1');
-  const res = await fetch(url.toString());
-  if (!res.ok) throw new Error('Recipes failed');
-  return res.json();
+  // Prefer canonical /prompt-templates; fall back to legacy /recipes if needed
+  const makeUrl = (path: string) => {
+    const u = new URL(`${API_BASE}${path}`)
+    if (reload) u.searchParams.set('reload', '1')
+    return u
+  }
+
+  // Try canonical endpoint first
+  let res = await fetch(makeUrl('/prompt-templates').toString())
+  if (!res.ok) {
+    // Fallback to legacy alias
+    res = await fetch(makeUrl('/recipes').toString())
+  }
+  if (!res.ok) throw new Error('Recipes failed')
+  return res.json()
 }
 
 export async function apiStatsGet(params: { assistant?: string; category?: string } = {}) {

--- a/sdk/python/neoprompt/src/neoprompt/client.py
+++ b/sdk/python/neoprompt/src/neoprompt/client.py
@@ -81,9 +81,11 @@ class Client:
         reward: Union[int, float],
         components: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        payload: Dict[str, Any] = {"decision_id": decision_id, "reward": float(reward)}
-        if components:
-            payload["reward_components"] = components
+        payload: Dict[str, Any] = {
+            "decision_id": decision_id,
+            "reward": float(reward),
+            "reward_components": components or {},
+        }
         r = self._request("POST", "/feedback", json=payload)
         r.raise_for_status()
         return r.json()

--- a/tests/cli/test_neoprompt_cli.py
+++ b/tests/cli/test_neoprompt_cli.py
@@ -1,7 +1,46 @@
 import subprocess, sys
 
+
 def test_neoprompt_help():
     cmd = [sys.executable, "-m", "backend.cli.neoprompt", "--help"]
     out = subprocess.check_output(cmd, text=True)
     assert "NeoPrompt CLI" in out
     assert "choose" in out
+
+
+def test_cli_feedback_defaults(monkeypatch):
+    # Define a local DummyResp to mimic httpx responses
+    class DummyResp:
+        def __init__(self, json_data, status_code=200):
+            self._json = json_data
+            self.status_code = status_code
+        def raise_for_status(self):
+            if not (200 <= self.status_code < 300):
+                raise AssertionError("HTTP error")
+        def json(self):
+            return self._json
+
+    captured = {}
+
+    def fake_request(self, method, url, **kwargs):
+        if method == "POST" and url == "/feedback":
+            captured["json"] = kwargs.get("json", {})
+            return DummyResp({"ok": True})
+        return DummyResp({}, 200)
+
+    monkeypatch.setattr("httpx.Client.request", fake_request)
+
+    # Import and invoke the CLI's main directly to avoid spawning a subprocess
+    from backend.cli import neoprompt
+
+    rc = neoprompt.main([
+        "--api-base", "http://example/api",
+        "feedback",
+        "--decision-id", "abc",
+        "--reward", "1",
+    ])
+    assert rc == 0
+    assert captured["json"]["decision_id"] == "abc"
+    assert captured["json"]["reward"] == 1.0
+    assert "reward_components" in captured["json"]
+    assert captured["json"]["reward_components"] == {}

--- a/tests/sdk_python/test_client.py
+++ b/tests/sdk_python/test_client.py
@@ -25,3 +25,40 @@ def test_client_builds(monkeypatch):
         assert c.health()["ok"] is True
         resp = c.choose("a", "b", "raw")
         assert "engineered_prompt" in resp
+
+
+def test_feedback_includes_empty_components_by_default(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, url, **kwargs):
+        if method == "POST" and url == "/feedback":
+            captured["json"] = kwargs.get("json", {})
+            return DummyResp({"ok": True})
+        return DummyResp({}, 200)
+
+    monkeypatch.setattr("httpx.Client.request", fake_request)
+    with Client(base_url="http://example/api") as c:
+        resp = c.feedback("dec123", reward=1)
+        assert resp == {"ok": True}
+        assert captured["json"]["decision_id"] == "dec123"
+        assert captured["json"]["reward"] == 1.0
+        assert "reward_components" in captured["json"]
+        assert captured["json"]["reward_components"] == {}
+
+
+def test_feedback_includes_passed_components(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, url, **kwargs):
+        if method == "POST" and url == "/feedback":
+            captured["json"] = kwargs.get("json", {})
+            return DummyResp({"ok": True})
+        return DummyResp({}, 200)
+
+    monkeypatch.setattr("httpx.Client.request", fake_request)
+    with Client(base_url="http://example/api") as c:
+        comps = {"hallucination": -0.5, "helpfulness": 1}
+        c.feedback("dec456", reward=-1, components=comps)
+        assert captured["json"]["decision_id"] == "dec456"
+        assert captured["json"]["reward"] == -1.0
+        assert captured["json"]["reward_components"] == comps


### PR DESCRIPTION
- **chore: sync untracked files and outstanding changes (auto-generated)**
- **ci: run backend/CLI tests only; install Python SDK before running SDK tests**
- **fix(ts-sdk): correct default base URL resolution for browser builds (avoid 'false' prefix)**
- **M0 tidy-ups: frontend prefers /prompt-templates (fallback to /recipes); optional JSON Schema validation in loader (behind env/strict); add jsonschema dep; replace Makefile fmt/lint/typecheck/test targets**
