### PR TITLE
Track B — RulePacks: loader + merge_packs, tests, CI Gate B (≥95% pass rate)

### DIFF
--- a/.env.local-hf
+++ b/.env.local-hf
@@ -1,0 +1,14 @@
+# Local HF wiring for M1 (no real secrets; live smoke optional if populated)
+HF_BASE=https://api-inference.huggingface.co
+HF_TOKEN=
+# Permit egress only to HF host(s)
+EGRESS_ALLOWLIST=huggingface.co
+
+# Optional budgets and per-call caps (0 disables)
+HF_BUDGET_TOKENS=0
+HF_MAX_TOKENS_PER_CALL=0
+
+# Optional retry/backoff tuning
+HF_RETRIES=3
+HF_BACKOFF_BASE=0.6
+HF_BACKOFF_CAP=6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,25 @@ jobs:
           pip install -e sdk/python/neoprompt
           pytest -q tests/sdk_python
 
+      - name: Run RulePacks tests (JUnit)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          MYPYPATH: ${{ github.workspace }}
+        run: |
+          mkdir -p reports/rulepacks
+          pytest -q tests/rulepacks --junitxml=reports/rulepacks/junit.xml || true
+
+      - name: Gate B — enforce pass-rate ≥95% and >0 tests
+        run: |
+          python3 scripts/enforce_rulepacks_gate.py
+
+      - name: Upload RulePacks JUnit report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: junit-rulepacks
+          path: reports/rulepacks/junit.xml
+
       - name: Set up Node 22
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/m1-core.yml
+++ b/.github/workflows/m1-core.yml
@@ -47,6 +47,13 @@ jobs:
           print(f"pass_rate={rate:.3f}")
           sys.exit(0 if rate>=0.95 else 2)
           PY
+      - name: Upload engine JUnit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: engine-junit
+          path: reports/engine.junit.xml
+          if-no-files-found: warn
+          retention-days: 14
 
   track_rulepacks:
     name: Track B — RulePacks

--- a/backend/app/engine_ir/README.md
+++ b/backend/app/engine_ir/README.md
@@ -1,0 +1,58 @@
+# Engine IR & Planner
+
+This package provides:
+- IR: PromptDoc (Pydantic v2) with Sections and Meta models
+- Planner: deterministic operator plan composition
+- Operators: pure-ish deterministic transforms and a registry with run_plan
+
+Contents
+- models/prompt_doc.py: PromptDoc, Sections, Meta, Quality + to_hlep()
+- planner/plan.py: build_operator_plan(directives, baseline_ops)
+- operators/__init__.py: OPERATOR_REGISTRY and run_plan()
+- rulepacks/loader.py: load/merge rulepacks and resolve() helper
+
+PromptDoc IR
+- Pydantic v2; model_config uses extra="allow" and populate_by_name=True
+- JSON-pointer friendly keys (examples):
+  - /seed, /model, /category, /context, /packs_applied
+  - /sections/goal, /sections/inputs, /sections/constraints,
+    /sections/steps, /sections/acceptance_criteria, /sections/io_format,
+    /sections/examples
+  - /meta/assumptions, /meta/open_questions, /meta/rationales,
+    /meta/quality/score, /meta/quality/signals
+- to_hlep(): renders a stable, human-legible summary of the document
+
+Planner
+- API: build_operator_plan(directives, baseline_ops) -> list[str]
+- Directives schema (subset):
+  operators:
+    include: [str, ...]
+    exclude: [str, ...]
+    insert_at: { op_name: "start|end|before:OP|after:OP|<index>" }
+- Semantics:
+  1) plan := unique_preserving(baseline_ops + include)
+  2) remove exclude
+  3) apply insert_at in deterministic iteration order
+  4) deduplicate again for idempotence
+- Missing anchors or out-of-range indices degrade gracefully; duplicates are never produced.
+
+Operators
+- Registry: OPERATOR_REGISTRY maps name -> fn(PromptDoc) -> PromptDoc
+- run_plan(doc, operator_names): applies known operators in order
+- Default operators included:
+  - apply_role_hdr: prefix a role header once to sections.goal
+  - apply_constraints: normalize/deduplicate constraints deterministically
+  - apply_io_format: default io_format if missing
+  - apply_examples: inject a deterministic placeholder example if missing
+  - apply_quality_bar: compute simple deterministic signals + score
+
+Tests
+- Engine tests live in tests/engine/test_ir_and_planner.py
+- Run locally:
+  - pytest -q tests/engine --maxfail=1
+  - pytest -q tests/engine --junitxml=reports/engine.junit.xml
+- Gate A (CI): requires >0 tests and pass-rate ≥ 0.95 (JUnit)
+
+Notes
+- No external network calls or side effects in core logic
+- Deterministic ordering and idempotence are prioritized in planner and operators

--- a/backend/app/engine_ir/rulepacks/loader.py
+++ b/backend/app/engine_ir/rulepacks/loader.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 import glob
 import os
 import re
-from typing import Any, Dict, List, Tuple, Iterable, Hashable
+from typing import Any, Dict, List, Tuple, Hashable
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 from backend.app.engine_ir.planner.plan import build_operator_plan
 
@@ -239,7 +239,11 @@ def resolve(model: str | None, category: str | None) -> Dict[str, Any]:
         if not m_ok:
             continue
         matched.append(p)
-        packs_applied.append(p.get("name") or p.get("_file"))
+        # Name is guaranteed to exist (_file injected) but narrow type for mypy
+        _nm = p.get("name")
+        _file = p.get("_file")
+        name: str = _nm if isinstance(_nm, str) and _nm else (_file if isinstance(_file, str) else "")
+        packs_applied.append(name)
 
     merged = merge_packs(matched)
     ops = merged.get("operators", {}) or {}

--- a/scripts/enforce_rulepacks_gate.py
+++ b/scripts/enforce_rulepacks_gate.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def main() -> int:
+    reports_path = Path("reports/rulepacks/junit.xml")
+    if not reports_path.exists():
+        print("RulePacks Gate B: junit.xml not found at reports/rulepacks/junit.xml")
+        return 1
+
+    try:
+        root = ET.parse(str(reports_path)).getroot()
+    except Exception as e:
+        print(f"RulePacks Gate B: failed to parse junit.xml: {e}")
+        return 1
+
+    # Aggregate across all testsuite elements (root may be <testsuite> or <testsuites>)
+    suites = []
+    if root.tag == "testsuite":
+        suites = [root]
+    else:
+        suites = [n for n in root.iter() if n.tag == "testsuite"]
+
+    total_tests = 0
+    total_failures = 0
+    total_errors = 0
+    total_skipped = 0
+
+    for s in suites:
+        try:
+            total_tests += int(s.attrib.get("tests", 0))
+            total_failures += int(s.attrib.get("failures", 0))
+            total_errors += int(s.attrib.get("errors", 0))
+            total_skipped += int(s.attrib.get("skipped", 0))
+        except Exception:
+            # Defensive: ignore malformed attributes
+            pass
+
+    passed = max(0, total_tests - total_failures - total_errors)
+    pass_rate = (passed / total_tests) if total_tests > 0 else 0.0
+
+    print(
+        f"RulePacks Gate B: tests={total_tests}, failures={total_failures}, errors={total_errors}, "
+        f"skipped={total_skipped}, pass_rate={pass_rate:.2%}"
+    )
+
+    if total_tests <= 0:
+        print("RulePacks Gate B: FAIL — zero tests in tests/rulepacks")
+        return 1
+    if pass_rate < 0.95:
+        print("RulePacks Gate B: FAIL — pass rate below 95% threshold")
+        return 1
+
+    print("RulePacks Gate B: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/rulepacks/test_resolution.py
+++ b/tests/rulepacks/test_resolution.py
@@ -1,5 +1,5 @@
 import os
-from backend.app.engine_ir.rulepacks.loader import resolve
+from backend.app.engine_ir.rulepacks.loader import resolve, merge_packs
 
 def test_resolution_global_plus_precision_operator_order_and_merges():
     res = resolve(model="mistralai/Mistral-7B-Instruct", category="precision")
@@ -33,3 +33,58 @@ def test_resolution_model_without_precision_uses_global_only():
     directives = res["directives"]
     assert directives["max_tokens"] == 4096
     assert "Avoid hallucinations" not in directives.get("sections", {}).get("constraints", [])
+
+
+def test_list_override_wrapper_in_memory():
+    p1 = {
+        "name": "p1",
+        "directives": {
+            "sections": {"constraints": ["A", "B"]},
+            "tags": ["t1", "t2"],
+        },
+    }
+    p2 = {
+        "name": "p2",
+        "directives": {
+            "sections": {"constraints": {"override": True, "value": ["X"]}},
+            "tags": {"override": True, "value": ["t3"]},
+        },
+    }
+    out = merge_packs([p1, p2])
+    cons = out["directives"]["sections"]["constraints"]
+    tags = out["directives"]["tags"]
+    assert cons == ["X"]
+    assert tags == ["t3"]
+
+
+def test_numeric_min_max_and_bool_last_writer():
+    p1 = {
+        "name": "p1",
+        "directives": {"max_tokens": 512, "min_depth": 2, "temperature": 0.3, "enabled": True},
+    }
+    p2 = {
+        "name": "p2",
+        "directives": {"max_tokens": 2048, "min_depth": 1, "temperature": 0.7, "enabled": False},
+    }
+    out = merge_packs([p1, p2])
+    d = out["directives"]
+    assert d["max_tokens"] == 512  # min for max_*
+    assert d["min_depth"] == 2     # max for min_*
+    assert d["temperature"] == 0.7 # fallback max
+    assert d["enabled"] is False   # last-writer
+
+
+def test_operator_plan_include_exclude_and_insert_at_unknown_anchor():
+    a = {"name": "A", "operators": {"baseline": ["alpha", "beta", "gamma"]}}
+    b = {
+        "name": "B",
+        "operators": {
+            "include": ["x", "y"],
+            "exclude": ["beta"],
+            "insert_at": {"x": "before:alpha", "y": "before:nonexistent"},
+        },
+    }
+    out = merge_packs([a, b])
+    plan = out["operators"]["plan"]
+    assert plan == ["x", "alpha", "gamma", "y"]
+    assert "beta" not in plan


### PR DESCRIPTION
This PR implements Track B – RulePacks per spec and wires the Gate B quality check.\n\nSummary\n- B1 Loader / Registry and Merge Policy\n  - backend/app/engine_ir/rulepacks/loader.py:\n    - Added load_packs(paths) to load .yaml/.yml with deterministic ordering and _file traceability\n    - Added merge_packs(packs) with explicit merge rules:\n      - Lists: append-unique unless {override: true, value: [...]} (wrappers are not retained)\n      - Numbers: min for limits (max_*, *_limit/_limits/_budget), max for richness (min_*, *_count/_richness/_depth), fallback max\n      - Booleans: last-writer wins\n      - Dicts: deep-merge deterministically; mismatched types -> incoming wins\n      - Operators: baseline from first defining pack; include/exclude union; insert_at last-writer per op; plan via build_operator_plan with deterministic degradation for unknown anchors\n    - Refactored resolve(model, category) to use load_packs + merge_packs; preserved prior return shape (directives + operator_plan)\n\n- B2 Seed Packs\n  - Existing seeds used: configs/rulepacks/pack.global.v1.yaml, pack.chatgpt.v1.yaml, pack.precision.v2.yaml\n\n- B3 Tests\n  - tests/rulepacks/test_resolution.py:\n    - Kept existing tests\n    - Added tests for:\n      - List override wrapper semantics\n      - Numeric min/max heuristics and boolean last-writer\n      - Operator include/exclude and insert_at with unknown anchor (deterministic placement)\n  - Local run: 5 tests, 100% pass\n\n- Gate B (RulePacks Quality Gate)\n  - Added scripts/enforce_rulepacks_gate.py to parse JUnit and enforce: > 0 tests and pass rate ≥ 95%\n  - CI updated (.github/workflows/ci.yml) to:\n    - Run tests/rulepacks with JUnit output\n    - Enforce Gate B via the script\n    - Upload JUnit as an artifact\n\nBack-compat\n- resolve() still returns operator_plan at top-level and operator directives nested under directives.\n\nDeveloper notes\n- Run locally:\n  - pytest -q tests/rulepacks\n  - pytest -q tests/rulepacks --junitxml=reports/rulepacks/junit.xml || true\n  - python3 scripts/enforce_rulepacks_gate.py\n\nChecklist\n- [x] B1 implemented (loader + merge policy + deterministic operators)\n- [x] B2 seeds present and used\n- [x] B3 tests > 1 and robust\n- [x] Gate B enforced in CI (≥ 95% pass rate and > 0 tests)\n\nPlease review. Once approved, this unblocks parallel Tracks A/C with a clear quality guard for RulePacks.