### PR TITLE
Add local HF compose profile for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ mise install
 mise trust .mise.toml
 ```
 
+### Docker Compose (local HF prep)
+
+To exercise the API in a container using the Hugging Face-ready profile (HF assist stays disabled in M1):
+
+1. Copy the default environment file if you have not already: `cp .env.example .env.local-hf` and adjust values as needed. Leave any `HF_*` tokens empty to avoid outbound Hugging Face calls.
+2. From the repo root, build and start the container: `docker compose -f infra/compose/docker-compose.local-hf.yml up --build`.
+
+The profile only launches the API service on port 8000 using `.env.local-hf`, so without credentials it runs completely offline.
+
 ### Backend
 ```bash
 cd backend

--- a/infra/compose/docker-compose.local-hf.yml
+++ b/infra/compose/docker-compose.local-hf.yml
@@ -1,15 +1,9 @@
-version: "3.9"
 services:
   api:
-    image: python:3.11-slim
-    working_dir: /app
-    command: bash -lc "pip install -r backend/requirements.txt && uvicorn backend.app.main:app --host 0.0.0.0 --port 8000"
-    volumes:
-      - ../../:/app:rw
+    build:
+      context: ../..
+      dockerfile: backend/Dockerfile
     env_file:
       - ../../.env.local-hf
     ports:
       - "8000:8000"
-    environment:
-      - CORS_ALLOWED_ORIGINS=*
-    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a lightweight docker compose file for the API that builds from the project root and reads `.env.local-hf`
- document how to launch the container for the Hugging Face prep workflow and note that HF assist stays disabled without credentials

## Testing
- not run (docs and configuration only)


------
https://chatgpt.com/codex/tasks/task_b_68d0a240d248832e9774bb8985877325