### PR TITLE
docs: document operating modes and provider policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ A local middleware tool that transforms raw user requests into optimized, assist
 - **Privacy-First**: Local SQLite storage, optional text persistence
 - **Optional Enhancement**: Local LLM for input clarification
 
+## Documentation
+
+- [Operating Modes](docs/OPERATING_MODES.md) – how to run NeoPrompt in Local-Only or Local + HF configurations and what modes are planned next.
+- [Provider Policy](docs/PROVIDER_POLICY.md) – provider allowlists, enforcement points, and example Hugging Face calls with expected errors.
+
 ## Architecture
 
 ```

--- a/docs/OPERATING_MODES.md
+++ b/docs/OPERATING_MODES.md
@@ -1,23 +1,31 @@
-# Operating Modes (M1)
+# Operating Modes
 
-NeoPrompt M1 supports:
-1) Local-only (offline): All /engine/* endpoints operate entirely offline using the Engine IR, Rulepacks, and deterministic Operators. No network calls are made.
-2) Local + HF (optional): The Hugging Face Serverless adapter is included but ONLY used if explicitly invoked and allowed. M1 tests do not require any outbound calls.
+NeoPrompt is designed to run safely in constrained environments while still being able to tap into optional hosted helpers. The platform currently recognises two primary modes, both of which share the same code paths and deployment artefacts—only configuration changes.
 
-## Environment
-- .env.local-hf provides:
-  - HF_TOKEN: HF API token (optional for live smoke)
-  - HF_BASE: Base API URL (default https://api-inference.huggingface.co)
-  - EGRESS_ALLOWLIST: host allowlist (e.g., huggingface.co) to prevent accidental egress
-  - Optional budgets: HF_BUDGET_TOKENS, HF_MAX_TOKENS_PER_CALL
-  - Optional retries/backoff: HF_RETRIES, HF_BACKOFF_BASE, HF_BACKOFF_CAP
+## Local-Only
 
-## Provider Registry
-- backend.app.adapters.providers.get_llm_provider("hf") returns an HFProvider instance.
-- Provider constructors do not perform network calls.
-- In M1, the HF adapter is exercised via mocked tests only; live smoke is optional and gated by an HF_TOKEN check.
+- **Audience**: Operators who must keep the stack entirely offline.
+- **Behaviour**: All `/engine/*` functionality executes with the local Engine IR, rulepacks, and deterministic operators. No outbound network calls are performed and the egress policy blocks any attempt to reach the public internet.
+- **How to enable**: Use the standard `.env` or `.env.local` file and the default Docker Compose profile. No Hugging Face credentials are required.
 
-## Metrics
-- Engine metrics: neopr_engine_requests_total, neopr_engine_latency_seconds
-- Provider metrics: neopr_hf_backoffs_total, neopr_hf_rate_limited_total
-- All exposed on /metrics via Prometheus client.
+## Local + HF Assist
+
+- **Audience**: Teams that want to remain offline by default but allow explicit access to Hugging Face's serverless inference endpoints when configured.
+- **Behaviour**: The core pipeline continues to run locally. The Hugging Face provider adapter is available for opt-in calls when an operator supplies the required credentials. In Milestone 1 this path remains disabled by default but the configuration is ready for live exercises.
+- **How to enable**:
+  - Copy `.env.local-hf` to `.env` (or supply its values through environment management tooling) to set `HF_TOKEN`, `HF_BASE` (defaults to `https://api-inference.huggingface.co`), and the `EGRESS_ALLOWLIST` entries for Hugging Face domains.
+  - Alternatively, select the `local-hf` Docker Compose profile to load the same variables without modifying the base configuration.
+- **Operational notes**: Budgets (`HF_BUDGET_TOKENS`, `HF_MAX_TOKENS_PER_CALL`) and retry knobs (`HF_RETRIES`, `HF_BACKOFF_BASE`, `HF_BACKOFF_CAP`) reside in the same `.env.local-hf` template. Leaving the values unset keeps the hosted path dormant.
+
+## Switching Between Modes
+
+Moving from one mode to another never requires a code change or redeploy. Switch the active `.env.*` file (for example, rename `.env.local` ↔ `.env.local-hf`) or start the stack with the corresponding Compose profile. The application reads configuration on startup and activates the right providers automatically.
+
+## Roadmap
+
+Forthcoming milestones introduce additional runtime profiles so teams can plan ahead:
+
+- **M3 – Replay Mode**: deterministic reprocessing of saved decisions for auditing.
+- **M4 – Stress Mode**: high-concurrency load runs with synthetic traffic.
+
+Documentation for new modes will land alongside those milestones, but the underlying principle remains: the same binaries run everywhere—configuration decides the behaviour.

--- a/docs/PROVIDER_POLICY.md
+++ b/docs/PROVIDER_POLICY.md
@@ -1,21 +1,50 @@
-# Provider Policy (M1)
+# Provider Policy
 
-## Egress Control
-- Outbound HTTP(S) calls are blocked unless the target host matches EGRESS_ALLOWLIST.
-- Error code: EGRESS_BLOCKED (HTTP 403 recommended).
+The provider adapter layer is the single gateway for any external LLM call. It is responsible for enforcing egress, budget, and rate controls before a request ever leaves the host.
 
-## Budgets and Cost Controls
-- Token/call budgets enforced pre-flight:
-  - HF_MAX_TOKENS_PER_CALL: per-call cap
-  - HF_BUDGET_TOKENS: coarse budget threshold
-- Exceeded budget error: LLM_BUDGET_EXCEEDED (HTTP 402 recommended).
+## Allowed Providers
+
+| Provider key | Description            | Allowlisted domains                      |
+|--------------|------------------------|-------------------------------------------|
+| `hf`         | Hugging Face Inference | `api-inference.huggingface.co` (default) |
+
+Additional providers join the table as they are onboarded. Operators may extend the allowlist through configuration, but the adapter validates that every outbound hostname matches an approved entry. Violations return `EGRESS_BLOCKED` (HTTP 403 recommended).
+
+## Example HF Invocation
+
+```http
+POST /models/bigscience/bloomz-560m HTTP/1.1
+Host: api-inference.huggingface.co
+Authorization: Bearer <HF_TOKEN>
+Content-Type: application/json
+
+{"inputs": "Summarise: NeoPrompt keeps prompts local by default."}
+```
+
+The adapter injects retry and timeout guards, serialises payloads, and collects request/response metadata for observability.
+
+## Error Codes
+
+- `EGRESS_BLOCKED`: Attempted call to a host outside the configured allowlist.
+- `LLM_RATE_LIMITED`: The upstream service returned 429 after the adapter exhausted backoff retries.
+- `LLM_COLD_START`: Upstream indicated a loading/cold start condition (e.g., 503 with retry hints) and the retry budget expired.
+- `LLM_BUDGET_EXCEEDED`: The request would exceed `LLM_COST_BUDGET_USD`, `HF_BUDGET_TOKENS`, or `HF_MAX_TOKENS_PER_CALL` constraints.
+- `LLM_ERROR`: All other non-retryable failures (HTTP 5xx/4xx).
+
+## Budgets and Rate Limits
+
+Budgeting and throttling occur inside the provider adapter. Each outbound call is checked against:
+
+- `LLM_COST_BUDGET_USD`: Aggregate spend ceiling shared across providers.
+- Token-oriented limits such as `HF_BUDGET_TOKENS` (rolling window) and `HF_MAX_TOKENS_PER_CALL` (per request).
+- Client-side rate guards that cap concurrent calls and respect provider guidance.
+
+If a limit trips, the adapter short-circuits the call locally and surfaces the appropriate error code. Successful calls update the trackers so subsequent requests see the latest spend/tokens state.
 
 ## Rate Limiting and Cold Starts
-- 429 Rate limits: Retries with exponential backoff and jitter; honors Retry-After if present.
-  - Error code on exhaustion: LLM_RATE_LIMITED (HTTP 429).
-- 503 Cold starts: Retries similarly; if exhausted with loading signals, map to LLM_COLD_START (HTTP 503).
-- neopr_hf_backoffs_total increments per backoff; neopr_hf_rate_limited_total increments on 429.
 
-## General Errors
-- Non-retryable errors: LLM_ERROR (HTTP 502/500).
-- M1 offline path never triggers provider calls; API remains deterministic and side-effect free.
+The adapter automatically retries when upstream returns `429` or temporary `5xx` codes, using exponential backoff with jitter. When retry attempts are depleted, it surfaces `LLM_RATE_LIMITED` or `LLM_COLD_START` as appropriate. Metrics such as `neopr_hf_backoffs_total` and `neopr_hf_rate_limited_total` provide visibility into these events.
+
+## Offline Guarantee
+
+In Local-Only mode the provider registry remains dormant, meaning the Hugging Face adapter is never invoked. The application continues to produce deterministic results with zero egress while still benefiting from the policy protections documented above should a hosted mode be enabled later.


### PR DESCRIPTION
## Summary
- expand the operating modes guide with clear Local-Only and Local + HF behaviour, switching guidance, and roadmap milestones
- rewrite the provider policy to document allowlists, error codes, budgets, and a sample Hugging Face request
- add a documentation section to the README that links to the new guides for quick discovery

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68d0a2aba8fc832ea96fef371ba18fb7